### PR TITLE
Fixed plugin name in Spring Boot Support page

### DIFF
--- a/src/jbake/content/spring-boot-support.asciidoc
+++ b/src/jbake/content/spring-boot-support.asciidoc
@@ -26,7 +26,7 @@ buildscript {
   }
 }
 
-apply plugin: 'gretty'
+apply plugin: 'org.akhikhl.gretty'
 
 repositories {
   jcenter()
@@ -60,7 +60,7 @@ buildscript {
   }
 }
 
-apply plugin: 'gretty'
+apply plugin: 'org.akhikhl.gretty'
 
 repositories {
   jcenter()


### PR DESCRIPTION
Currently http://akhikhl.github.io/gretty-doc/spring-boot-support.html refers to plugin `gretty` instead of `org.akhikhl.gretty`, so the examples don't work.
