### PR TITLE
Close first table on page Gretty configuration.

### DIFF
--- a/src/jbake/content/Gretty-configuration.asciidoc
+++ b/src/jbake/content/Gretty-configuration.asciidoc
@@ -247,6 +247,7 @@ Note that interactiveMode only affects interactive tasks: appRun, appRunDebug, f
 | String
 | gretty_port.properties
 | Specifies name of file for gretty service and status port.
+|===
 
 == Web-app-specific properties
 


### PR DESCRIPTION
The section "Web-app-specific properties" is afterwards displayed as a table.
