### PR TITLE
Fix typo/container versions

### DIFF
--- a/Switching-between-servlet-containers.html
+++ b/Switching-between-servlet-containers.html
@@ -132,7 +132,7 @@ farm {
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">servetContainer</th>
+<th class="tableblock halign-left valign-top">servletContainer</th>
 <th class="tableblock halign-left valign-top">Servlet container version</th>
 <th class="tableblock halign-left valign-top">Servlet API version</th>
 </tr>
@@ -154,12 +154,12 @@ farm {
 <td class="tableblock halign-left valign-top"><p class="tableblock">3.1.0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">jetty93</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">jetty9.3</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Jetty 9.3.20.v20170531</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">3.1.0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">jetty94</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">jetty9.4</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Jetty 9.4.6.v20170531</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">3.1.0</p></td>
 </tr>


### PR DESCRIPTION
- Fixes a typo in `servetContainer`
- Servlet containers such as `jetty93` and `jetty94` should be registered as `jetty9.3`, etc.